### PR TITLE
Retain some platform sources

### DIFF
--- a/src/build/cleanup.sh
+++ b/src/build/cleanup.sh
@@ -3,5 +3,20 @@
 set -o errexit -o nounset
 
 if [ "$CLEAN_SRC" == "1" ]; then
+    mkdir -p /dotnet/src-tmp/platform
+
+    cp -r /dotnet/src/platform/coreclr /dotnet/src-tmp/platform
+    rm -r /dotnet/src-tmp/platform/coreclr/bin
+    rm -r /dotnet/src-tmp/platform/coreclr/.git
+
+    cp -r /dotnet/src/platform/corefx /dotnet/src-tmp/platform
+    rm -r /dotnet/src-tmp/platform/corefx/artifacts
+    rm -r /dotnet/src-tmp/platform/corefx/.git
+
+    cp -r /dotnet/src/platform/corert /dotnet/src-tmp/platform
+    rm -r /dotnet/src-tmp/platform/corert/bin
+    rm -r /dotnet/src-tmp/platform/corert/.git
+
     rm -r /dotnet/src
+    mv /dotnet/src-tmp /dotnet/src
 fi


### PR DESCRIPTION
Now that our container is a lot smaller, we can retain some sources that were previously excluded purely to keep the size down.

Having these available should make debugging more useful.